### PR TITLE
fix: mount_points fails on null on tf 0.13

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -171,7 +171,7 @@ variable "mount_points" {
     containerPath = string
     sourceVolume  = string
   }))
-  default = null
+  default = []
 }
 
 variable "port_mappings" {


### PR DESCRIPTION
Fixes error on TF 0.13 when mount_point is null

Fixes #21 