### PR TITLE
Bump cn-terraform/ecs-fargate-service/aws to 2.0.16

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "td" {
 #------------------------------------------------------------------------------
 module "ecs-fargate-service" {
   source  = "cn-terraform/ecs-fargate-service/aws"
-  version = "2.0.15"
+  version = "2.0.16"
   # source  = "../terraform-aws-ecs-fargate-service"
 
   name_prefix = var.name_prefix


### PR DESCRIPTION
Brings it in line with https://github.com/cn-terraform/terraform-aws-ecs-fargate-service/commit/0bd1f5987c940d18ab85706c80cff50c8815e5d5

Allows for using `target_group_protocol` variable. 